### PR TITLE
Refactor destroy-landing-zone script to exclude specific resource groups

### DIFF
--- a/accelerator/scripts/destroy-landing-zone.ps1
+++ b/accelerator/scripts/destroy-landing-zone.ps1
@@ -91,7 +91,7 @@ ForEach ($subscription in $subscriptionsToClean) {
     Set-AzContext -Subscription $subscription.id | Out-Null
 
     # Get all Resource Groups in Subscription
-    $resourceGroups = Get-AzResourceGroup
+    $resourceGroups = Get-AzResourceGroup | Where-Object { $_.ResourceGroupName -notlike "rg-alz-mgmt-agents*" -and $_.ResourceGroupName -notlike "rg-alz-mgmt-identity*" }
 
     $resourceGroupsToRemove = @()
     ForEach ($resourceGroup in $resourceGroups) {


### PR DESCRIPTION
This pull request includes a targeted change to the `destroy-landing-zone.ps1` script to improve the filtering of resource groups in Azure subscriptions.

Filtering improvements:

* [`accelerator/scripts/destroy-landing-zone.ps1`](diffhunk://#diff-afd414bb2182e067dbead860c5e11f60a7f3efb63164217ad0ff6e8a51e5cd3dL94-R94): Modified the `Get-AzResourceGroup` command to exclude resource groups with names that match the patterns "rg-alz-mgmt-agents*" and "rg-alz-mgmt-identity*".